### PR TITLE
ZUUL-2015 - Expand result as body on success

### DIFF
--- a/packages/@uppy/aws-s3-multipart/src/index.js
+++ b/packages/@uppy/aws-s3-multipart/src/index.js
@@ -159,6 +159,9 @@ module.exports = class AwsS3Multipart extends Plugin {
 
       const onSuccess = (result) => {
         const uploadResp = {
+          body: {
+            ...result
+          },
           uploadURL: result.location
         }
 


### PR DESCRIPTION
expands the result into a body on success. Tested by modifying node_modules locally and was able to see that companion return of key and bucket was in the body.

This will need to be PR'd into the transloadit repo and released to get it. Provides a backwards compatible solution to  https://github.com/transloadit/uppy/issues/1890 